### PR TITLE
RFC: Enable filesystem-specific features

### DIFF
--- a/src/fs/apfs.cpp
+++ b/src/fs/apfs.cpp
@@ -23,8 +23,8 @@ FileSystem::CommandSupportType apfs::m_Move = FileSystem::cmdSupportCore;
 FileSystem::CommandSupportType apfs::m_Copy = FileSystem::cmdSupportCore;
 FileSystem::CommandSupportType apfs::m_Backup = FileSystem::cmdSupportCore;
 
-apfs::apfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::Apfs)
+apfs::apfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Apfs)
 {
 }
 }

--- a/src/fs/apfs.h
+++ b/src/fs/apfs.h
@@ -34,7 +34,7 @@ namespace FS
 class LIBKPMCORE_EXPORT apfs : public FileSystem
 {
 public:
-    apfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    apfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
     CommandSupportType supportMove() const override {

--- a/src/fs/bitlocker.cpp
+++ b/src/fs/bitlocker.cpp
@@ -23,8 +23,8 @@ FileSystem::CommandSupportType bitlocker::m_Move = FileSystem::cmdSupportCore;
 FileSystem::CommandSupportType bitlocker::m_Copy = FileSystem::cmdSupportCore;
 FileSystem::CommandSupportType bitlocker::m_Backup = FileSystem::cmdSupportCore;
 
-bitlocker::bitlocker(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::BitLocker)
+bitlocker::bitlocker(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::BitLocker)
 {
 }
 }

--- a/src/fs/bitlocker.h
+++ b/src/fs/bitlocker.h
@@ -34,7 +34,7 @@ namespace FS
 class LIBKPMCORE_EXPORT bitlocker : public FileSystem
 {
 public:
-    bitlocker(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    bitlocker(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
     CommandSupportType supportMove() const override {

--- a/src/fs/btrfs.cpp
+++ b/src/fs/btrfs.cpp
@@ -132,6 +132,18 @@ bool btrfs::create(Report& report, const QString& deviceNode)
     return cmd.run(-1) && cmd.exitCode() == 0;
 }
 
+bool btrfs::createWithFeatures(Report& report, const QString& deviceNode, const QStringList& features)
+{
+    QStringList args = QStringList();
+
+    if (features.count() > 0)
+        args << QStringLiteral("--features") << features.join(QStringLiteral(","));
+    args << QStringLiteral("--force") << deviceNode;
+
+    ExternalCommand cmd(report, QStringLiteral("mkfs.btrfs"), args);
+    return cmd.run(-1) && cmd.exitCode() == 0;
+}
+
 bool btrfs::resize(Report& report, const QString& deviceNode, qint64 length) const
 {
     QTemporaryDir tempDir;

--- a/src/fs/btrfs.cpp
+++ b/src/fs/btrfs.cpp
@@ -43,8 +43,8 @@ FileSystem::CommandSupportType btrfs::m_SetLabel = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType btrfs::m_UpdateUUID = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType btrfs::m_GetUUID = FileSystem::cmdSupportNone;
 
-btrfs::btrfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::Btrfs)
+btrfs::btrfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Btrfs)
 {
 }
 

--- a/src/fs/btrfs.h
+++ b/src/fs/btrfs.h
@@ -38,7 +38,7 @@ namespace FS
 class LIBKPMCORE_EXPORT btrfs : public FileSystem
 {
 public:
-    btrfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    btrfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
     void init() override;

--- a/src/fs/btrfs.h
+++ b/src/fs/btrfs.h
@@ -46,6 +46,7 @@ public:
     qint64 readUsedCapacity(const QString& deviceNode) const override;
     bool check(Report& report, const QString& deviceNode) const override;
     bool create(Report& report, const QString& deviceNode) override;
+    bool createWithFeatures(Report& report, const QString& deviceNode, const QStringList& features) override;
     bool resize(Report& report, const QString& deviceNode, qint64 length) const override;
     bool resizeOnline(Report& report, const QString& deviceNode, const QString& mountPoint, qint64 length) const override;
     bool writeLabel(Report& report, const QString& deviceNode, const QString& newLabel) override;
@@ -59,6 +60,9 @@ public:
         return m_GetLabel;
     }
     CommandSupportType supportCreate() const override {
+        return m_Create;
+    }
+    CommandSupportType supportCreateWithFeatures() const override {
         return m_Create;
     }
     CommandSupportType supportGrow() const override {

--- a/src/fs/exfat.cpp
+++ b/src/fs/exfat.cpp
@@ -38,8 +38,8 @@ FileSystem::CommandSupportType exfat::m_SetLabel = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType exfat::m_UpdateUUID = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType exfat::m_GetUUID = FileSystem::cmdSupportNone;
 
-exfat::exfat(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::Exfat)
+exfat::exfat(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Exfat)
 {
 }
 

--- a/src/fs/exfat.h
+++ b/src/fs/exfat.h
@@ -37,7 +37,7 @@ namespace FS
 class LIBKPMCORE_EXPORT exfat : public FileSystem
 {
 public:
-    exfat(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    exfat(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
     void init() override;

--- a/src/fs/ext2.cpp
+++ b/src/fs/ext2.cpp
@@ -39,8 +39,8 @@ FileSystem::CommandSupportType ext2::m_SetLabel = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType ext2::m_UpdateUUID = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType ext2::m_GetUUID = FileSystem::cmdSupportNone;
 
-ext2::ext2(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, FileSystem::Type t) :
-    FileSystem(firstsector, lastsector, sectorsused, label, t)
+ext2::ext2(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features, FileSystem::Type t) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, t)
 {
 }
 

--- a/src/fs/ext2.cpp
+++ b/src/fs/ext2.cpp
@@ -137,6 +137,18 @@ bool ext2::create(Report& report, const QString& deviceNode)
     return cmd.run(-1) && cmd.exitCode() == 0;
 }
 
+bool ext2::createWithFeatures(Report& report, const QString& deviceNode, const QStringList& features)
+{
+    QStringList args = QStringList();
+
+    if (features.count() > 0)
+        args << QStringLiteral("-O") << features.join(QStringLiteral(","));
+    args << QStringLiteral("-qF") << deviceNode;
+
+    ExternalCommand cmd(report, QStringLiteral("mkfs.ext2"), args);
+    return cmd.run(-1) && cmd.exitCode() == 0;
+}
+
 bool ext2::resize(Report& report, const QString& deviceNode, qint64 length) const
 {
     const QString len = QString::number(length / 512) + QStringLiteral("s");

--- a/src/fs/ext2.h
+++ b/src/fs/ext2.h
@@ -45,6 +45,7 @@ public:
     qint64 readUsedCapacity(const QString& deviceNode) const override;
     bool check(Report& report, const QString& deviceNode) const override;
     bool create(Report& report, const QString& deviceNode) override;
+    bool createWithFeatures(Report& report, const QString& deviceNode, const QStringList& features) override;
     bool resize(Report& report, const QString& deviceNode, qint64 length) const override;
     bool writeLabel(Report& report, const QString& deviceNode, const QString& newLabel) override;
     bool writeLabelOnline(Report& report, const QString& deviceNode, const QString& mountPoint, const QString& newLabel) override;
@@ -57,6 +58,9 @@ public:
         return m_GetLabel;
     }
     CommandSupportType supportCreate() const override {
+        return m_Create;
+    }
+    CommandSupportType supportCreateWithFeatures() const override {
         return m_Create;
     }
     CommandSupportType supportGrow() const override {

--- a/src/fs/ext2.h
+++ b/src/fs/ext2.h
@@ -37,7 +37,7 @@ namespace FS
 class LIBKPMCORE_EXPORT ext2 : public FileSystem
 {
 public:
-    ext2(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, FileSystem::Type t = FileSystem::Type::Ext2);
+    ext2(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList(), FileSystem::Type t = FileSystem::Type::Ext2);
 
 public:
     void init() override;

--- a/src/fs/ext3.cpp
+++ b/src/fs/ext3.cpp
@@ -24,8 +24,8 @@
 
 namespace FS
 {
-ext3::ext3(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    ext2(firstsector, lastsector, sectorsused, label, FileSystem::Type::Ext3)
+ext3::ext3(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    ext2(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Ext3)
 {
 }
 

--- a/src/fs/ext3.cpp
+++ b/src/fs/ext3.cpp
@@ -40,6 +40,18 @@ bool ext3::create(Report& report, const QString& deviceNode)
     return cmd.run(-1) && cmd.exitCode() == 0;
 }
 
+bool ext3::createWithFeatures(Report& report, const QString& deviceNode, const QStringList& features)
+{
+    QStringList args = QStringList();
+
+    if (features.count() > 0)
+        args << QStringLiteral("-O") << features.join(QStringLiteral(","));
+    args << QStringLiteral("-qF") << deviceNode;
+
+    ExternalCommand cmd(report, QStringLiteral("mkfs.ext3"), args);
+    return cmd.run(-1) && cmd.exitCode() == 0;
+}
+
 bool ext3::resizeOnline(Report& report, const QString& deviceNode, const QString&, qint64 length) const
 {
     return resize(report, deviceNode, length);

--- a/src/fs/ext3.h
+++ b/src/fs/ext3.h
@@ -44,6 +44,7 @@ public:
 
 public:
     bool create(Report& report, const QString& deviceNode) override;
+    bool createWithFeatures(Report& report, const QString& deviceNode, const QStringList& features) override;
     bool resizeOnline(Report& report, const QString& deviceNode, const QString& mountPoint, qint64 length) const override;
     qint64 maxCapacity() const override;
 

--- a/src/fs/ext3.h
+++ b/src/fs/ext3.h
@@ -40,7 +40,7 @@ namespace FS
 class LIBKPMCORE_EXPORT ext3 : public ext2
 {
 public:
-    ext3(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    ext3(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
     bool create(Report& report, const QString& deviceNode) override;

--- a/src/fs/ext4.cpp
+++ b/src/fs/ext4.cpp
@@ -40,6 +40,18 @@ bool ext4::create(Report& report, const QString& deviceNode)
     return cmd.run(-1) && cmd.exitCode() == 0;
 }
 
+bool ext4::createWithFeatures(Report& report, const QString& deviceNode, const QStringList& features)
+{
+    QStringList args = QStringList();
+
+    if (features.count() > 0)
+        args << QStringLiteral("-O") << features.join(QStringLiteral(","));
+    args << QStringLiteral("-qF") << deviceNode;
+
+    ExternalCommand cmd(report, QStringLiteral("mkfs.ext4"), args);
+    return cmd.run(-1) && cmd.exitCode() == 0;
+}
+
 bool ext4::resizeOnline(Report& report, const QString& deviceNode, const QString&, qint64 length) const
 {
     return resize(report, deviceNode, length);

--- a/src/fs/ext4.cpp
+++ b/src/fs/ext4.cpp
@@ -24,8 +24,8 @@
 
 namespace FS
 {
-ext4::ext4(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    ext2(firstsector, lastsector, sectorsused, label, FileSystem::Type::Ext4)
+ext4::ext4(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    ext2(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Ext4)
 {
 }
 

--- a/src/fs/ext4.h
+++ b/src/fs/ext4.h
@@ -40,7 +40,7 @@ namespace FS
 class LIBKPMCORE_EXPORT ext4 : public ext2
 {
 public:
-    ext4(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    ext4(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
     bool create(Report& report, const QString& deviceNode) override;

--- a/src/fs/ext4.h
+++ b/src/fs/ext4.h
@@ -44,6 +44,7 @@ public:
 
 public:
     bool create(Report& report, const QString& deviceNode) override;
+    bool createWithFeatures(Report& report, const QString& deviceNode, const QStringList& features) override;
     bool resizeOnline(Report& report, const QString& deviceNode, const QString& mountPoint, qint64 length) const override;
     qint64 maxCapacity() const override;
 

--- a/src/fs/extended.cpp
+++ b/src/fs/extended.cpp
@@ -24,8 +24,8 @@ FileSystem::CommandSupportType extended::m_Grow = FileSystem::cmdSupportCore;
 FileSystem::CommandSupportType extended::m_Shrink = FileSystem::cmdSupportCore;
 FileSystem::CommandSupportType extended::m_Move = FileSystem::cmdSupportCore;
 
-extended::extended(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::Extended)
+extended::extended(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Extended)
 {
 }
 

--- a/src/fs/extended.h
+++ b/src/fs/extended.h
@@ -40,7 +40,7 @@ namespace FS
 class LIBKPMCORE_EXPORT extended : public FileSystem
 {
 public:
-    extended(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    extended(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
 

--- a/src/fs/f2fs.cpp
+++ b/src/fs/f2fs.cpp
@@ -45,8 +45,8 @@ FileSystem::CommandSupportType f2fs::m_UpdateUUID = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType f2fs::m_GetUUID = FileSystem::cmdSupportNone;
 bool f2fs::oldVersion = false; // 1.8.x or older
 
-f2fs::f2fs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::F2fs)
+f2fs::f2fs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::F2fs)
 {
 }
 

--- a/src/fs/f2fs.h
+++ b/src/fs/f2fs.h
@@ -36,7 +36,7 @@ namespace FS
 class LIBKPMCORE_EXPORT f2fs : public FileSystem
 {
 public:
-    f2fs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    f2fs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
     void init() override;

--- a/src/fs/fat12.cpp
+++ b/src/fs/fat12.cpp
@@ -46,8 +46,8 @@ FileSystem::CommandSupportType fat12::m_Backup = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType fat12::m_UpdateUUID = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType fat12::m_GetUUID = FileSystem::cmdSupportNone;
 
-fat12::fat12(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, FileSystem::Type t) :
-    FileSystem(firstsector, lastsector, sectorsused, label, t)
+fat12::fat12(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features, FileSystem::Type t) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, t)
 {
 }
 

--- a/src/fs/fat12.h
+++ b/src/fs/fat12.h
@@ -37,7 +37,7 @@ namespace FS
 class LIBKPMCORE_EXPORT fat12 : public FileSystem
 {
 public:
-    fat12(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, FileSystem::Type t = FileSystem::Type::Fat12);
+    fat12(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList(), FileSystem::Type t = FileSystem::Type::Fat12);
 
 public:
     void init() override;

--- a/src/fs/fat16.cpp
+++ b/src/fs/fat16.cpp
@@ -31,11 +31,6 @@
 
 namespace FS
 {
-fat16::fat16(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    fat12(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Fat16)
-{
-}
-
 fat16::fat16(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features, FileSystem::Type type) :
     fat12(firstsector, lastsector, sectorsused, label, features, type)
 {

--- a/src/fs/fat16.cpp
+++ b/src/fs/fat16.cpp
@@ -32,12 +32,12 @@
 namespace FS
 {
 fat16::fat16(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    fat12(firstsector, lastsector, sectorsused, label, FileSystem::Type::Fat16)
+    fat12(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Fat16)
 {
 }
 
-fat16::fat16(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, FileSystem::Type type) :
-    fat12(firstsector, lastsector, sectorsused, label, type)
+fat16::fat16(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features, FileSystem::Type type) :
+    fat12(firstsector, lastsector, sectorsused, label, features, type)
 {
 }
 

--- a/src/fs/fat16.h
+++ b/src/fs/fat16.h
@@ -33,7 +33,6 @@ namespace FS
 class LIBKPMCORE_EXPORT fat16 : public fat12
 {
 public:
-    fat16(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
     fat16(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList(), FileSystem::Type type = FileSystem::Type::Fat16);
 
 public:

--- a/src/fs/fat16.h
+++ b/src/fs/fat16.h
@@ -34,7 +34,7 @@ class LIBKPMCORE_EXPORT fat16 : public fat12
 {
 public:
     fat16(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
-    fat16(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, FileSystem::Type type);
+    fat16(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList(), FileSystem::Type type = FileSystem::Type::Fat16);
 
 public:
     void init() override;

--- a/src/fs/fat32.cpp
+++ b/src/fs/fat32.cpp
@@ -26,8 +26,8 @@
 
 namespace FS
 {
-fat32::fat32(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    fat16(firstsector, lastsector, sectorsused, label, FileSystem::Type::Fat32)
+fat32::fat32(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    fat16(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Fat32)
 {
 }
 

--- a/src/fs/fat32.h
+++ b/src/fs/fat32.h
@@ -40,7 +40,7 @@ namespace FS
 class LIBKPMCORE_EXPORT fat32 : public fat16
 {
 public:
-    fat32(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    fat32(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
     bool create(Report& report, const QString& deviceNode) override;

--- a/src/fs/filesystem.cpp
+++ b/src/fs/filesystem.cpp
@@ -84,6 +84,7 @@ struct FileSystemPrivate {
     qint64 m_SectorsUsed;
     QString m_Label;
     QString m_UUID;
+    QStringList m_Features;
 };
 
 /** Creates a new FileSystem object
@@ -101,6 +102,26 @@ FileSystem::FileSystem(qint64 firstsector, qint64 lastsector, qint64 sectorsused
     d->m_LastSector = lastsector;
     d->m_SectorsUsed = sectorsused;
     d->m_Label = label;
+    d->m_UUID = QString();
+}
+
+/** Creates a new FileSystem object
+    @param firstsector the first sector used by this FileSystem on the Device
+    @param lastsector the last sector used by this FileSystem on the Device
+    @param sectorsused the number of sectors in use on the FileSystem
+    @param label the FileSystem label
+    @param features the FileSystem features
+    @param type the FileSystem type
+*/
+FileSystem::FileSystem(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features, FileSystem::Type type) :
+    d(std::make_unique<FileSystemPrivate>())
+{
+    d->m_Type = type;
+    d->m_FirstSector = firstsector;
+    d->m_LastSector = lastsector;
+    d->m_SectorsUsed = sectorsused;
+    d->m_Label = label;
+    d->m_Features = features;
     d->m_UUID = QString();
 }
 
@@ -192,6 +213,21 @@ bool FileSystem::createWithLabel(Report& report, const QString& deviceNode, cons
     Q_UNUSED(report)
     Q_UNUSED(deviceNode)
     Q_UNUSED(label)
+
+    return true;
+}
+
+/** Creates a new FileSystem with a specified features set
+    @param report Report to write status information to
+    @param deviceNode the device node for the Partition to create the FileSystem on
+    @param features the list of features for the FileSystem
+    @return true if successful
+*/
+bool FileSystem::createWithFeatures(Report& report, const QString& deviceNode, const QStringList& features)
+{
+    Q_UNUSED(report)
+    Q_UNUSED(deviceNode)
+    Q_UNUSED(features)
 
     return true;
 }
@@ -605,6 +641,11 @@ void FileSystem::setLastSector(qint64 s)
 const QString& FileSystem::label() const
 {
     return d->m_Label;
+}
+
+const QStringList& FileSystem::features() const
+{
+    return d->m_Features;
 }
 
 qint64 FileSystem::sectorSize() const

--- a/src/fs/filesystem.h
+++ b/src/fs/filesystem.h
@@ -113,6 +113,7 @@ public:
 
 protected:
     FileSystem(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, FileSystem::Type type);
+    FileSystem(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features, FileSystem::Type type);
 
 public:
     virtual ~FileSystem();
@@ -124,6 +125,7 @@ public:
     virtual QString readLabel(const QString& deviceNode) const;
     virtual bool create(Report& report, const QString& deviceNode);
     virtual bool createWithLabel(Report& report, const QString& deviceNode, const QString& label);
+    virtual bool createWithFeatures(Report& report, const QString& deviceNode, const QStringList& features);
     virtual bool resize(Report& report, const QString& deviceNode, qint64 newLength) const;
     virtual bool resizeOnline(Report& report, const QString& deviceNode, const QString& mountPoint, qint64 newLength) const;
     virtual bool move(Report& report, const QString& deviceNode, qint64 newStartSector) const;
@@ -147,6 +149,9 @@ public:
         return cmdSupportNone;    /**< @return CommandSupportType for creating */
     }
     virtual CommandSupportType supportCreateWithLabel() const {
+        return cmdSupportNone;    /**< @return CommandSupportType for creating */
+    }
+    virtual CommandSupportType supportCreateWithFeatures() const {
         return cmdSupportNone;    /**< @return CommandSupportType for creating */
     }
     virtual CommandSupportType supportGrow() const {
@@ -262,6 +267,9 @@ public:
 
     /**< @return the FileSystem's label */
     const QString& label() const;
+
+    /**< @return the FileSystem's features */
+    const QStringList& features() const;
 
     /**< @return the sector size in the underlying Device */
     qint64 sectorSize() const;

--- a/src/fs/filesystemfactory.cpp
+++ b/src/fs/filesystemfactory.cpp
@@ -114,45 +114,45 @@ void FileSystemFactory::init()
     @param label the FileSystem's label
     @return pointer to the newly created FileSystem object or nullptr if FileSystem could not be created
 */
-FileSystem* FileSystemFactory::create(FileSystem::Type t, qint64 firstsector, qint64 lastsector, qint64 sectorSize, qint64 sectorsused, const QString& label, const QString& uuid)
+FileSystem* FileSystemFactory::create(FileSystem::Type t, qint64 firstsector, qint64 lastsector, qint64 sectorSize, qint64 sectorsused, const QString& label, const QStringList& features, const QString& uuid)
 {
     FileSystem* fs = nullptr;
 
     switch (t) {
-    case FileSystem::Type::Apfs:            fs = new FS::apfs           (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::BitLocker:       fs = new FS::bitlocker      (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Btrfs:           fs = new FS::btrfs          (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Exfat:           fs = new FS::exfat          (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Ext2:            fs = new FS::ext2           (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Ext3:            fs = new FS::ext3           (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Ext4:            fs = new FS::ext4           (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Extended:        fs = new FS::extended       (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::F2fs:            fs = new FS::f2fs           (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Fat12:           fs = new FS::fat12          (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Fat16:           fs = new FS::fat16          (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Fat32:           fs = new FS::fat32          (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Hfs:             fs = new FS::hfs            (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::HfsPlus:         fs = new FS::hfsplus        (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Hpfs:            fs = new FS::hpfs           (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Iso9660:         fs = new FS::iso9660        (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Jfs:             fs = new FS::jfs            (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::LinuxRaidMember: fs = new FS::linuxraidmember(firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::LinuxSwap:       fs = new FS::linuxswap      (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Luks:            fs = new FS::luks           (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Luks2:           fs = new FS::luks2          (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Lvm2_PV:         fs = new FS::lvm2_pv        (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Minix:           fs = new FS::minix          (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Nilfs2:          fs = new FS::nilfs2         (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Ntfs:            fs = new FS::ntfs           (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Ocfs2:           fs = new FS::ocfs2          (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::ReiserFS:        fs = new FS::reiserfs       (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Reiser4:         fs = new FS::reiser4        (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Udf:             fs = new FS::udf            (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Ufs:             fs = new FS::ufs            (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Unformatted:     fs = new FS::unformatted    (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Unknown:         fs = new FS::unknown        (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Xfs:             fs = new FS::xfs            (firstsector, lastsector, sectorsused, label); break;
-    case FileSystem::Type::Zfs:             fs = new FS::zfs            (firstsector, lastsector, sectorsused, label); break;
+    case FileSystem::Type::Apfs:            fs = new FS::apfs           (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::BitLocker:       fs = new FS::bitlocker      (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Btrfs:           fs = new FS::btrfs          (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Exfat:           fs = new FS::exfat          (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Ext2:            fs = new FS::ext2           (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Ext3:            fs = new FS::ext3           (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Ext4:            fs = new FS::ext4           (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Extended:        fs = new FS::extended       (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::F2fs:            fs = new FS::f2fs           (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Fat12:           fs = new FS::fat12          (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Fat16:           fs = new FS::fat16          (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Fat32:           fs = new FS::fat32          (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Hfs:             fs = new FS::hfs            (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::HfsPlus:         fs = new FS::hfsplus        (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Hpfs:            fs = new FS::hpfs           (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Iso9660:         fs = new FS::iso9660        (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Jfs:             fs = new FS::jfs            (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::LinuxRaidMember: fs = new FS::linuxraidmember(firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::LinuxSwap:       fs = new FS::linuxswap      (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Luks:            fs = new FS::luks           (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Luks2:           fs = new FS::luks2          (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Lvm2_PV:         fs = new FS::lvm2_pv        (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Minix:           fs = new FS::minix          (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Nilfs2:          fs = new FS::nilfs2         (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Ntfs:            fs = new FS::ntfs           (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Ocfs2:           fs = new FS::ocfs2          (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::ReiserFS:        fs = new FS::reiserfs       (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Reiser4:         fs = new FS::reiser4        (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Udf:             fs = new FS::udf            (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Ufs:             fs = new FS::ufs            (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Unformatted:     fs = new FS::unformatted    (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Unknown:         fs = new FS::unknown        (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Xfs:             fs = new FS::xfs            (firstsector, lastsector, sectorsused, label, features); break;
+    case FileSystem::Type::Zfs:             fs = new FS::zfs            (firstsector, lastsector, sectorsused, label, features); break;
     default:                       break;
     }
 
@@ -169,7 +169,7 @@ FileSystem* FileSystemFactory::create(FileSystem::Type t, qint64 firstsector, qi
 */
 FileSystem* FileSystemFactory::create(const FileSystem& other)
 {
-    return create(other.type(), other.firstSector(), other.lastSector(), other.sectorSize(), other.sectorsUsed(), other.label(), other.uuid());
+    return create(other.type(), other.firstSector(), other.lastSector(), other.sectorSize(), other.sectorsUsed(), other.label(), other.features(), other.uuid());
 }
 
 /** @return the map of FileSystems */
@@ -185,5 +185,5 @@ const FileSystemFactory::FileSystems& FileSystemFactory::map()
 */
 FileSystem* FileSystemFactory::cloneWithNewType(FileSystem::Type newType, const FileSystem& other)
 {
-    return create(newType, other.firstSector(), other.lastSector(), other.sectorSize(), other.sectorsUsed(), other.label());
+    return create(newType, other.firstSector(), other.lastSector(), other.sectorSize(), other.sectorsUsed(), other.label(), other.features());
 }

--- a/src/fs/filesystemfactory.h
+++ b/src/fs/filesystemfactory.h
@@ -41,7 +41,7 @@ private:
 
 public:
     static void init();
-    static FileSystem* create(FileSystem::Type t, qint64 firstsector, qint64 lastsector, qint64 sectorSize, qint64 sectorsused = -1, const QString& label = QString(), const QString& uuid = QString());
+    static FileSystem* create(FileSystem::Type t, qint64 firstsector, qint64 lastsector, qint64 sectorSize, qint64 sectorsused = -1, const QString& label = QString(), const QStringList& features = QStringList(), const QString& uuid = QString());
     static FileSystem* create(const FileSystem& other);
     static FileSystem* cloneWithNewType(FileSystem::Type newType, const FileSystem& other);
     static const FileSystems& map();

--- a/src/fs/hfs.cpp
+++ b/src/fs/hfs.cpp
@@ -34,8 +34,8 @@ FileSystem::CommandSupportType hfs::m_Check = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType hfs::m_Copy = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType hfs::m_Backup = FileSystem::cmdSupportNone;
 
-hfs::hfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::Hfs)
+hfs::hfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Hfs)
 {
 }
 

--- a/src/fs/hfs.h
+++ b/src/fs/hfs.h
@@ -37,7 +37,7 @@ namespace FS
 class LIBKPMCORE_EXPORT hfs : public FileSystem
 {
 public:
-    hfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    hfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
     void init() override;

--- a/src/fs/hfsplus.cpp
+++ b/src/fs/hfsplus.cpp
@@ -34,8 +34,8 @@ FileSystem::CommandSupportType hfsplus::m_Create = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType hfsplus::m_Copy = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType hfsplus::m_Backup = FileSystem::cmdSupportNone;
 
-hfsplus::hfsplus(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::HfsPlus)
+hfsplus::hfsplus(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::HfsPlus)
 {
 }
 

--- a/src/fs/hfsplus.h
+++ b/src/fs/hfsplus.h
@@ -37,7 +37,7 @@ namespace FS
 class LIBKPMCORE_EXPORT hfsplus : public FileSystem
 {
 public:
-    hfsplus(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    hfsplus(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
     void init() override;

--- a/src/fs/hpfs.cpp
+++ b/src/fs/hpfs.cpp
@@ -36,8 +36,8 @@ FileSystem::CommandSupportType hpfs::m_SetLabel = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType hpfs::m_UpdateUUID = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType hpfs::m_GetUUID = FileSystem::cmdSupportNone;
 
-hpfs::hpfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::Hpfs)
+hpfs::hpfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Hpfs)
 {
 }
 

--- a/src/fs/hpfs.h
+++ b/src/fs/hpfs.h
@@ -37,7 +37,7 @@ namespace FS
 class LIBKPMCORE_EXPORT hpfs : public FileSystem
 {
 public:
-    hpfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    hpfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
     CommandSupportType supportGetUsed() const override {

--- a/src/fs/iso9660.cpp
+++ b/src/fs/iso9660.cpp
@@ -20,8 +20,8 @@
 namespace FS
 {
 
-iso9660::iso9660(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::Iso9660)
+iso9660::iso9660(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Iso9660)
 {
 }
 

--- a/src/fs/iso9660.h
+++ b/src/fs/iso9660.h
@@ -35,7 +35,7 @@ namespace FS
 class LIBKPMCORE_EXPORT iso9660 : public FileSystem
 {
 public:
-    iso9660(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    iso9660(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 };
 

--- a/src/fs/jfs.cpp
+++ b/src/fs/jfs.cpp
@@ -39,8 +39,8 @@ FileSystem::CommandSupportType jfs::m_Copy = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType jfs::m_Backup = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType jfs::m_SetLabel = FileSystem::cmdSupportNone;
 
-jfs::jfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::Jfs)
+jfs::jfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Jfs)
 {
 }
 

--- a/src/fs/jfs.h
+++ b/src/fs/jfs.h
@@ -37,7 +37,7 @@ namespace FS
 class LIBKPMCORE_EXPORT jfs : public FileSystem
 {
 public:
-    jfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    jfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
     void init() override;

--- a/src/fs/linuxraidmember.cpp
+++ b/src/fs/linuxraidmember.cpp
@@ -20,8 +20,8 @@
 namespace FS
 {
 
-linuxraidmember::linuxraidmember(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::LinuxRaidMember)
+linuxraidmember::linuxraidmember(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::LinuxRaidMember)
 {
 }
 

--- a/src/fs/linuxraidmember.h
+++ b/src/fs/linuxraidmember.h
@@ -34,7 +34,7 @@ namespace FS
 class LIBKPMCORE_EXPORT linuxraidmember : public FileSystem
 {
 public:
-    linuxraidmember(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    linuxraidmember(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 };
 }
 

--- a/src/fs/linuxswap.cpp
+++ b/src/fs/linuxswap.cpp
@@ -39,8 +39,8 @@ FileSystem::CommandSupportType linuxswap::m_SetLabel = FileSystem::cmdSupportNon
 FileSystem::CommandSupportType linuxswap::m_GetUUID = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType linuxswap::m_UpdateUUID = FileSystem::cmdSupportNone;
 
-linuxswap::linuxswap(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::LinuxSwap)
+linuxswap::linuxswap(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::LinuxSwap)
 {
 }
 

--- a/src/fs/linuxswap.h
+++ b/src/fs/linuxswap.h
@@ -37,7 +37,7 @@ namespace FS
 class LIBKPMCORE_EXPORT linuxswap : public FileSystem
 {
 public:
-    linuxswap(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    linuxswap(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
     void init() override;

--- a/src/fs/luks.cpp
+++ b/src/fs/luks.cpp
@@ -63,8 +63,9 @@ luks::luks(qint64 firstsector,
            qint64 lastsector,
            qint64 sectorsused,
            const QString& label,
+           const QStringList& features,
            FileSystem::Type t)
-    : FileSystem(firstsector, lastsector, sectorsused, label, t)
+    : FileSystem(firstsector, lastsector, sectorsused, label, features, t)
     , m_innerFs(nullptr)
     , m_isCryptOpen(false)
     , m_cryptsetupFound(m_Create != cmdSupportNone)

--- a/src/fs/luks.h
+++ b/src/fs/luks.h
@@ -39,7 +39,7 @@ namespace FS
 class LIBKPMCORE_EXPORT luks : public FileSystem
 {
 public:
-    luks(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, FileSystem::Type t = FileSystem::Type::Luks);
+    luks(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList(), FileSystem::Type t = FileSystem::Type::Luks);
     ~luks() override;
 
     enum class KeyLocation {

--- a/src/fs/luks2.cpp
+++ b/src/fs/luks2.cpp
@@ -27,8 +27,8 @@
 namespace FS
 {
 
-luks2::luks2(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label)
-    : luks(firstsector, lastsector, sectorsused, label, FileSystem::Type::Luks2)
+luks2::luks2(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features)
+    : luks(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Luks2)
 {
 }
 

--- a/src/fs/luks2.h
+++ b/src/fs/luks2.h
@@ -35,7 +35,7 @@ namespace FS
 class LIBKPMCORE_EXPORT luks2 : public luks
 {
 public:
-    luks2(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    luks2(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
     ~luks2() override;
 
     bool create(Report& report, const QString& deviceNode) override;

--- a/src/fs/lvm2_pv.cpp
+++ b/src/fs/lvm2_pv.cpp
@@ -42,8 +42,8 @@ FileSystem::CommandSupportType lvm2_pv::m_UpdateUUID = FileSystem::cmdSupportNon
 FileSystem::CommandSupportType lvm2_pv::m_GetUUID = FileSystem::cmdSupportNone;
 
 lvm2_pv::lvm2_pv(qint64 firstsector, qint64 lastsector,
-                 qint64 sectorsused, const QString& label)
-    : FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::Lvm2_PV)
+                 qint64 sectorsused, const QString& label, const QStringList& features)
+    : FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Lvm2_PV)
     , m_PESize(0)
     , m_TotalPE(0)
     , m_AllocatedPE(0)

--- a/src/fs/lvm2_pv.h
+++ b/src/fs/lvm2_pv.h
@@ -89,7 +89,7 @@ class LIBKPMCORE_EXPORT lvm2_pv : public FileSystem
 {
 
 public:
-    lvm2_pv(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    lvm2_pv(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
     void init() override;

--- a/src/fs/minix.cpp
+++ b/src/fs/minix.cpp
@@ -33,8 +33,8 @@ FileSystem::CommandSupportType minix::m_Create = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType minix::m_Copy = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType minix::m_Backup = FileSystem::cmdSupportNone;
 
-minix::minix(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::Minix)
+minix::minix(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Minix)
 {
 }
 

--- a/src/fs/minix.h
+++ b/src/fs/minix.h
@@ -34,8 +34,8 @@ namespace FS
 class LIBKPMCORE_EXPORT minix : public FileSystem
 {
 public:
-    minix(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
-    
+    minix(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
+
     void init() override;
     
     bool check(Report& report, const QString&deviceNode) const override;

--- a/src/fs/nilfs2.cpp
+++ b/src/fs/nilfs2.cpp
@@ -46,8 +46,8 @@ FileSystem::CommandSupportType nilfs2::m_SetLabel = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType nilfs2::m_UpdateUUID = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType nilfs2::m_GetUUID = FileSystem::cmdSupportNone;
 
-nilfs2::nilfs2(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::Nilfs2)
+nilfs2::nilfs2(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Nilfs2)
 {
 }
 

--- a/src/fs/nilfs2.h
+++ b/src/fs/nilfs2.h
@@ -38,7 +38,7 @@ namespace FS
 class LIBKPMCORE_EXPORT nilfs2 : public FileSystem
 {
 public:
-    nilfs2(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    nilfs2(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
     void init() override;

--- a/src/fs/ntfs.cpp
+++ b/src/fs/ntfs.cpp
@@ -48,8 +48,8 @@ FileSystem::CommandSupportType ntfs::m_SetLabel = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType ntfs::m_UpdateUUID = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType ntfs::m_GetUUID = FileSystem::cmdSupportNone;
 
-ntfs::ntfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::Ntfs)
+ntfs::ntfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Ntfs)
 {
 }
 

--- a/src/fs/ntfs.h
+++ b/src/fs/ntfs.h
@@ -37,7 +37,7 @@ namespace FS
 class LIBKPMCORE_EXPORT ntfs : public FileSystem
 {
 public:
-    ntfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    ntfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
     void init() override;

--- a/src/fs/ocfs2.cpp
+++ b/src/fs/ocfs2.cpp
@@ -39,8 +39,8 @@ FileSystem::CommandSupportType ocfs2::m_SetLabel = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType ocfs2::m_UpdateUUID = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType ocfs2::m_GetUUID = FileSystem::cmdSupportNone;
 
-ocfs2::ocfs2(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::Ocfs2)
+ocfs2::ocfs2(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Ocfs2)
 {
 }
 

--- a/src/fs/ocfs2.h
+++ b/src/fs/ocfs2.h
@@ -37,7 +37,7 @@ namespace FS
 class LIBKPMCORE_EXPORT ocfs2 : public FileSystem
 {
 public:
-    ocfs2(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    ocfs2(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
     void init() override;

--- a/src/fs/reiser4.cpp
+++ b/src/fs/reiser4.cpp
@@ -34,8 +34,8 @@ FileSystem::CommandSupportType reiser4::m_Check = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType reiser4::m_Copy = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType reiser4::m_Backup = FileSystem::cmdSupportNone;
 
-reiser4::reiser4(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::Reiser4)
+reiser4::reiser4(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Reiser4)
 {
 }
 

--- a/src/fs/reiser4.h
+++ b/src/fs/reiser4.h
@@ -37,7 +37,7 @@ namespace FS
 class LIBKPMCORE_EXPORT reiser4 : public FileSystem
 {
 public:
-    reiser4(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    reiser4(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
     void init() override;

--- a/src/fs/reiserfs.cpp
+++ b/src/fs/reiserfs.cpp
@@ -41,8 +41,8 @@ FileSystem::CommandSupportType reiserfs::m_SetLabel = FileSystem::cmdSupportNone
 FileSystem::CommandSupportType reiserfs::m_UpdateUUID = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType reiserfs::m_GetUUID = FileSystem::cmdSupportNone;
 
-reiserfs::reiserfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::ReiserFS)
+reiserfs::reiserfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::ReiserFS)
 {
 }
 

--- a/src/fs/reiserfs.h
+++ b/src/fs/reiserfs.h
@@ -39,7 +39,7 @@ namespace FS
 class LIBKPMCORE_EXPORT reiserfs : public FileSystem
 {
 public:
-    reiserfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    reiserfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
     void init() override;

--- a/src/fs/udf.cpp
+++ b/src/fs/udf.cpp
@@ -39,8 +39,8 @@ FileSystem::CommandSupportType udf::m_UpdateUUID = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType udf::m_Create = FileSystem::cmdSupportNone;
 bool udf::oldMkudffsVersion = false;
 
-udf::udf(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::Udf)
+udf::udf(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Udf)
 {
 }
 

--- a/src/fs/udf.h
+++ b/src/fs/udf.h
@@ -37,7 +37,7 @@ namespace FS
 class LIBKPMCORE_EXPORT udf : public FileSystem
 {
 public:
-    udf(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    udf(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
     void init() override;

--- a/src/fs/ufs.cpp
+++ b/src/fs/ufs.cpp
@@ -23,8 +23,8 @@ FileSystem::CommandSupportType ufs::m_Move = FileSystem::cmdSupportCore;
 FileSystem::CommandSupportType ufs::m_Copy = FileSystem::cmdSupportCore;
 FileSystem::CommandSupportType ufs::m_Backup = FileSystem::cmdSupportCore;
 
-ufs::ufs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::Ufs)
+ufs::ufs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Ufs)
 {
 }
 }

--- a/src/fs/ufs.h
+++ b/src/fs/ufs.h
@@ -35,7 +35,7 @@ namespace FS
 class LIBKPMCORE_EXPORT ufs : public FileSystem
 {
 public:
-    ufs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    ufs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
     CommandSupportType supportMove() const override {

--- a/src/fs/unformatted.cpp
+++ b/src/fs/unformatted.cpp
@@ -21,8 +21,8 @@ namespace FS
 {
 FileSystem::CommandSupportType unformatted::m_Create = FileSystem::cmdSupportFileSystem;
 
-unformatted::unformatted(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::Unformatted)
+unformatted::unformatted(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Unformatted)
 {
 }
 

--- a/src/fs/unformatted.h
+++ b/src/fs/unformatted.h
@@ -37,7 +37,7 @@ namespace FS
 class LIBKPMCORE_EXPORT unformatted : public FileSystem
 {
 public:
-    unformatted(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    unformatted(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
     bool create(Report&, const QString&) override;

--- a/src/fs/unknown.cpp
+++ b/src/fs/unknown.cpp
@@ -22,8 +22,8 @@ namespace FS
 
 FileSystem::CommandSupportType unknown::m_Move = FileSystem::cmdSupportNone;
 
-unknown::unknown(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::Unknown)
+unknown::unknown(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Unknown)
 {
 }
 

--- a/src/fs/unknown.h
+++ b/src/fs/unknown.h
@@ -32,7 +32,7 @@ namespace FS
 class LIBKPMCORE_EXPORT unknown : public FileSystem
 {
 public:
-    unknown(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    unknown(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
     bool supportToolFound() const override {

--- a/src/fs/xfs.cpp
+++ b/src/fs/xfs.cpp
@@ -41,8 +41,8 @@ FileSystem::CommandSupportType xfs::m_Copy = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType xfs::m_Backup = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType xfs::m_SetLabel = FileSystem::cmdSupportNone;
 
-xfs::xfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::Xfs)
+xfs::xfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Xfs)
 {
 }
 

--- a/src/fs/xfs.h
+++ b/src/fs/xfs.h
@@ -37,7 +37,7 @@ namespace FS
 class LIBKPMCORE_EXPORT xfs : public FileSystem
 {
 public:
-    xfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    xfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
     void init() override;

--- a/src/fs/zfs.cpp
+++ b/src/fs/zfs.cpp
@@ -39,8 +39,8 @@ FileSystem::CommandSupportType zfs::m_SetLabel = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType zfs::m_UpdateUUID = FileSystem::cmdSupportNone;
 FileSystem::CommandSupportType zfs::m_GetUUID = FileSystem::cmdSupportNone;
 
-zfs::zfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label) :
-    FileSystem(firstsector, lastsector, sectorsused, label, FileSystem::Type::Zfs)
+zfs::zfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features) :
+    FileSystem(firstsector, lastsector, sectorsused, label, features, FileSystem::Type::Zfs)
 {
 }
 

--- a/src/fs/zfs.h
+++ b/src/fs/zfs.h
@@ -38,7 +38,7 @@ namespace FS
 class LIBKPMCORE_EXPORT zfs : public FileSystem
 {
 public:
-    zfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label);
+    zfs(qint64 firstsector, qint64 lastsector, qint64 sectorsused, const QString& label, const QStringList& features = QStringList());
 
 public:
     void init() override;

--- a/src/jobs/createfilesystemjob.h
+++ b/src/jobs/createfilesystemjob.h
@@ -33,7 +33,7 @@ class QString;
 class CreateFileSystemJob : public Job
 {
 public:
-    CreateFileSystemJob(Device& d, Partition& p, const QString& label = {});
+    CreateFileSystemJob(Device& d, Partition& p, const QString& label = {}, const QStringList& features = {});
 
 public:
     bool run(Report& parent) override;
@@ -58,6 +58,7 @@ private:
     Device& m_Device;
     Partition& m_Partition;
     const QString& m_Label;
+    const QStringList& m_Features;
 };
 
 #endif


### PR DESCRIPTION
In some cases, it may be necessary to create a filesystem with specific features enabled/disabled.

This PR is a proposal of an API extension, making it possible to create filesystems this way. It does so by introducing a new `m_Features` member variable and the `createWithFeatures()` function to the FileSystem base class. The latter function is implemented for the btrfs and ext2/3/4 filesystems.

Additionnally, the `CreateFileSystemJob` has been modified to enable creating/formatting filesystems with specific features enabled.

Please note this PR should be considered *work in progress*: most filesystems lack a proper implementation, and it has not been thoroughly tested. However, it is open for discussion, and comments are more than welcome.