### PR TITLE
FAT12 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+FAT12 support
+
 # KPMcore
 
 > KPMcore, the KDE Partition Manager core, is a library for examining


### PR DESCRIPTION
I need to resize a floppy image from 1440KB _(1474560 bytes)_ "High Density" aka standard floppy to 2880KB _(2949120 bytes)_ "Extended Density" floppy, and sadly discovered there are no opensource Linux tools for that! Manual hexedit of 0x13/0x14 bytes from 0x0B40 to 0x1680 and 0x18 byte from 0x12 to 0x24 - also didn't work for me _(but I just learned about FAT structure and may be missing something)_.

Please add FAT12 resizing support - it may be really important in some situations.