### PR TITLE
lvm without arguments has returncode 3

### DIFF
--- a/src/fs/lvm2_pv.cpp
+++ b/src/fs/lvm2_pv.cpp
@@ -46,7 +46,7 @@ lvm2_pv::lvm2_pv(qint64 firstsector, qint64 lastsector,
 
 void lvm2_pv::init()
 {
-    CommandSupportType lvmFound = findExternal(QStringLiteral("lvm")) ? cmdSupportFileSystem : cmdSupportNone;
+    CommandSupportType lvmFound = findExternal(QStringLiteral("lvm"), {}, 3) ? cmdSupportFileSystem : cmdSupportNone;
 
     m_Create     = lvmFound;
     m_Check      = lvmFound;


### PR DESCRIPTION
At least on nixos.