### PR TITLE
Change LUKS default sector size to 4096

### DIFF
--- a/src/fs/luks.cpp
+++ b/src/fs/luks.cpp
@@ -120,6 +120,7 @@ bool luks::create(Report& report, const QString& deviceNode)
     ExternalCommand createCmd(report, QStringLiteral("cryptsetup"),
                               { QStringLiteral("-s"),
                                 QStringLiteral("512"),
+                                QStringLiteral("--sector-size"), QStringLiteral("4096"),
                                 QStringLiteral("--batch-mode"),
                                 QStringLiteral("--force-password"),
                                 QStringLiteral("--type"), QStringLiteral("luks1"),

--- a/src/fs/luks2.cpp
+++ b/src/fs/luks2.cpp
@@ -40,6 +40,7 @@ bool luks2::create(Report& report, const QString& deviceNode)
     Q_ASSERT(!m_passphrase.isEmpty());
 
     QStringList createCmdArgs = { QStringLiteral("--use-random"),
+                                  QStringLiteral("--sector-size"), QStringLiteral("4096"),
                                   QStringLiteral("--key-size"), QStringLiteral("512"),
                                   QStringLiteral("--hash"), QStringLiteral("sha512"),
                                   QStringLiteral("--batch-mode"),


### PR DESCRIPTION
Hi. I noticed that currently luks.cpp  luks2.cpp using default sector size - 512B.
Most (all) modern user SSDs and HDDs using 4k sector size.
And setting it to 512B lead in some cases to huge perf degradation (SMR HDDs) (QLC SSDs) especially sensitive to this.
Using 4K as default will help a lot.

Fedora for example using 4k for default - [Changes/LUKSEncryptionSectorSize - Fedora Project Wiki](https://fedoraproject.org/wiki/Changes/LUKSEncryptionSectorSize)

So this commit adds --sector-size 4096 to both luks and luks2 CMDs.
This should not have any impact on encryption strengths and other things.

I am also doing  it on request of Calamares installer users. Because it uses kpmcore for LUKS initiation.